### PR TITLE
Update nldc landcover URL.

### DIFF
--- a/demcoreg/get_nlcd.sh
+++ b/demcoreg/get_nlcd.sh
@@ -23,7 +23,7 @@ nlcd_fn='nlcd_2011_landcover_2011_edition_2014_10_10/nlcd_2011_landcover_2011_ed
 
 if [ ! -e $nlcd_zip_fn ] ; then
     echo "Downloading $nlcd_zip_fn"
-    url='http://www.landfire.gov/bulk/downloadfile.php?TYPE=nlcd2011&FNAME=nlcd_2011_landcover_2011_edition_2014_10_10.zip'
+    url='https://landfire.cr.usgs.gov/MRLC/NLCD/nlcd_2011_landcover_2011_edition_2014_10_10.zip'
     wget -O $nlcd_zip_fn $url 
 fi
 


### PR DESCRIPTION
Source has moved permanently (301).

This will address the two redirects (see below) when downloading the dataset via `get_nldc.sh`
```
Downloading nlcd_2011_landcover_2011_edition_2014_10_10.zip
--2018-09-26 16:12:01--  http://www.landfire.gov/bulk/downloadfile.php?TYPE=nlcd2011&FNAME=nlcd_2011_landcover_2011_edition_2014_10_10.zip
Resolving www.landfire.gov... 2001:49c8:4000:122c::1032, 152.61.137.32
Connecting to www.landfire.gov|2001:49c8:4000:122c::1032|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://www.landfire.gov/bulk/downloadfile.php?TYPE=nlcd2011&FNAME=nlcd_2011_landcover_2011_edition_2014_10_10.zip [following]
--2018-09-26 16:12:05--  https://www.landfire.gov/bulk/downloadfile.php?TYPE=nlcd2011&FNAME=nlcd_2011_landcover_2011_edition_2014_10_10.zip
Connecting to www.landfire.gov|2001:49c8:4000:122c::1032|:443... connected.
HTTP request sent, awaiting response... 302 Moved Temporarily
Location: https://landfire.cr.usgs.gov/MRLC/NLCD/nlcd_2011_landcover_2011_edition_2014_10_10.zip?ORIG=137_singlelfr&SIZEMB=17881 [following]
--2018-09-26 16:12:08--  https://landfire.cr.usgs.gov/MRLC/NLCD/nlcd_2011_landcover_2011_edition_2014_10_10.zip?ORIG=137_singlelfr&SIZEMB=17881
Resolving landfire.cr.usgs.gov... 2001:49c8:4000:122c::1032, 152.61.137.32
Connecting to landfire.cr.usgs.gov|2001:49c8:4000:122c::1032|:443... connected.

```