### PR TITLE
Fix NCLD endpoint

### DIFF
--- a/demcoreg/dem_mask.py
+++ b/demcoreg/dem_mask.py
@@ -44,7 +44,7 @@ def get_nlcd_fn(yr=2016):
     #get_nlcd.sh creates a compressed GTiff, which is 1.1 GB
     #nlcd_fn = os.path.join(datadir, 'nlcd_2011_landcover_2011_edition_2014_10_10/nlcd_2011_landcover_2011_edition_2014_10_10.tif')
     #nlcd_fn = os.path.join(datadir, 'NLCD_{0}_Land_Cover_L48_20190424/NLCD_{0}_Land_Cover_L48_20190424.tif'.format(str(yr)))
-    nlcd_fn = os.path.join(datadir, 'NLCD_{0}_Land_Cover_L48_20190424.tif'.format(str(yr)))
+    nlcd_fn = os.path.join(datadir, 'nlcd_{0}_land_cover_l48_20210604.tif'.format(str(yr)))
     if not os.path.exists(nlcd_fn):
         cmd = ['get_nlcd.sh', str(yr)]
         #subprocess.call(cmd)

--- a/demcoreg/get_nlcd.sh
+++ b/demcoreg/get_nlcd.sh
@@ -31,9 +31,9 @@ fi
 cd $DATADIR
 
 #CONUS Land Cover (NLCD) grids, 30 m from https://www.mrlc.gov/data
-url="https://s3-us-west-2.amazonaws.com/mrlc/NLCD_${yr}_Land_Cover_L48_20190424.zip"
-nlcd_zip_fn="NLCD_${yr}_Land_Cover_L48_20190424.zip"
-nlcd_fn="NLCD_${yr}_Land_Cover_L48_20190424.tif"
+url="https://s3-us-west-2.amazonaws.com/mrlc/nlcd_${yr}_land_cover_l48_20210604.zip"
+nlcd_zip_fn="nlcd_${yr}_land_cover_l48_20210604.zip"
+nlcd_fn="nlcd_${yr}_land_cover_l48_20210604.tif"
 nlcd_dir=${nlcd_zip_fn%.*}
 
 if [ ! -e $nlcd_zip_fn ] ; then


### PR DESCRIPTION
Looks like the NLCD endpoint has changed from 

https://s3-us-west-2.amazonaws.com/mrlc/NLCD_2016_Land_Cover_L48_20190424.zip 

to 

https://s3-us-west-2.amazonaws.com/mrlc/nlcd_2016_land_cover_l48_20210604.zip

These changes should handle access to the right endpoint and finding the unzipped file locally.