### PR TITLE
fix to update creation of array from ragged nested sequences

### DIFF
--- a/demcoreg/coreglib.py
+++ b/demcoreg/coreglib.py
@@ -334,7 +334,7 @@ def compute_offset_nuth(dh, slope, aspect, min_count=100, remove_outliers=True, 
             s=3
             #This is inefficient, but we have list of arrays with different length, need to filter
             #Reduntant with earlier filter, should refactor
-            bp = ax.boxplot(np.array(output)[idx][::s], positions=bin_centers[::s], widths=widths[::s], showfliers=False, \
+            bp = ax.boxplot(np.array(output,dtype=object)[idx][::s], positions=bin_centers[::s], widths=widths[::s], showfliers=False, \
                     patch_artist=True, boxprops=boxprops, whiskerprops=whiskerprops, capprops=capprops, \
                     medianprops=medianprops)
             bin_ticks = [0, 45, 90, 135, 180, 225, 270, 315, 360]


### PR DESCRIPTION
Hi David,
Creation of a numpy array from a list of tuples now requires using dtype=object when the array is initialized. See [solution here](#https://community.ibm.com/community/user/ai-datascience/discussion/creating-an-ndarray-from-ragged-nested-sequenceswhich-is-a-list-or-tuple-of-lists-or-tuples-or-ndarrays-with-different-lengths-shapesis-deprecated). I checked and the results are the same with this addition in the final plot. A user reported that the code was exiting in newer version of numpy.