### PR TITLE
Replace arr.ptp() with np.ptp(arr) and fix float type issues for JSON serialization

### DIFF
--- a/demcoreg/coreglib.py
+++ b/demcoreg/coreglib.py
@@ -151,8 +151,8 @@ def compute_offset_ncc(dem1, dem2, pad=(9,9), prefilter=False, plot=False):
     #ref_noise = ref.mask * ref.std() * np.random.rand(*ref.shape) + ref.mean()
     #kernel_noise = kernel.mask * kernel.std() * np.random.rand(*kernel.shape) + kernel.mean()
     #This provides noise in proper range, but noise propagates to m, peak is in different locations!
-    #ref_noise = ref.mask * (ref.min() + ref.ptp() * np.random.rand(*ref.shape))
-    #kernel_noise = kernel.mask * (kernel.min() + kernel.ptp() * np.random.rand(*kernel.shape))
+    #ref_noise = ref.mask * (ref.min() + np.ptp(ref) * np.random.rand(*ref.shape))
+    #kernel_noise = kernel.mask * (kernel.min() + np.ptp(kernel) * np.random.rand(*kernel.shape))
 
     #This provides a proper normal distribution with mean=0 and std=1
     ref_noise = ref.mask * (np.random.randn(*ref.shape))
@@ -294,7 +294,7 @@ def compute_offset_nuth(dh, slope, aspect, min_count=100, remove_outliers=True, 
     
     #Not going to help if we have a step function between two plateaus, but better than nothing
     #Calculate bin aspect spread
-    bin_ptp = np.cos(np.radians(bin_centers)).ptp()
+    bin_ptp = np.ptp(np.cos(np.radians(bin_centers)))
     min_bin_ptp = 1.0 
 
     #Should iterate here, if not enough bins, increase bin width

--- a/demcoreg/dem_align.py
+++ b/demcoreg/dem_align.py
@@ -545,7 +545,7 @@ def main(argv=None):
         align_stats['res']['coreg'] = res
         align_stats['center_coord'] = {'lon':center_coord_ll[0], 'lat':center_coord_ll[1], \
                 'x':center_coord_xy[0], 'y':center_coord_xy[1]}
-        align_stats['shift'] = {'dx':dx_total, 'dy':dy_total, 'dz':dz_total, 'dm':dm_total}
+        align_stats['shift'] = {'dx':dx_total, 'dy':dy_total, 'dz':np.float64(dz_total), 'dm':dm_total}
         #This tiltcorr flag gets set to false, need better flag
         if tiltcorr:
             align_stats['tiltcorr'] = {}

--- a/demcoreg/dem_align.py
+++ b/demcoreg/dem_align.py
@@ -409,7 +409,7 @@ def main(argv=None):
                 #Want to have max_tilt check here
                 #max_tilt = 4.0 #m
                 #Should do percentage
-                #vals.ptp() > max_tilt
+                #np.ptp(vals) > max_tilt
 
                 #Note: dimensions of ds and vals will be different as vals are computed for clipped intersection
                 #Need to recompute planar offset for full src_dem_ds_align extent and apply


### PR DESCRIPTION
This pull request addresses two issues in the code related to NumPy and JSON serialization:

**1. Replacing arr.ptp() with np.ptp(arr)**

The first issue was caused by the deprecated arr.ptp() method, which resulted in the following error:

```
AttributeError: 'ptp' was removed from the ndarray class in NumPy 2.0. Use np.ptp(arr, ...) instead.
```

To fix this, all instances of arr.ptp() were replaced with np.ptp(arr), following the recommended migration path for compatibility with NumPy 2.0.

**2. Fixing TypeError for JSON Serialization**

The second issue occurred when attempting to serialize align_stats into JSON, causing the following error:

```
TypeError: Object of type float32 is not JSON serializable
```

This was due to the dz variable produced by compute_offset being type np.float32, which is not directly JSON serializable. This was resolved by converting dz_total to np.float64 as it is included in the align_stats dictionary.

**Changes**

- Replaced all instances of arr.ptp() with np.ptp(arr) for NumPy 2.0 compatibility.
- Converted dz_total to np.float64 to avoid TypeError during JSON serialization.

**Note**
This was tested in a fresh conda environment as outlined in [Beginner's guide for installation and basic usage](https://github.com/dshean/demcoreg/blob/master/docs/beginners_doc.md).